### PR TITLE
Display configuration manager before scanning ROMs

### DIFF
--- a/src/wx-ui/wx-app.cc
+++ b/src/wx-ui/wx-app.cc
@@ -89,18 +89,20 @@ Frame::Frame(App *app, const wxString &title, const wxPoint &pos, const wxSize &
         CenterOnScreen();
 }
 
-void Frame::Start() {
-        if (wx_start(this))
-                ShowConfigSelection();
-        else
-                Quit(0);
-}
+void Frame::Start() { ShowConfigSelection(); }
 
 void Frame::ShowConfigSelection() {
-        if (wx_load_config(this))
-                start_emulation(this);
-        else
+        if (!wx_load_config(this)) {
                 Quit(1);
+                return;
+        }
+
+        if (!wx_start(this)) {
+                Quit(0);
+                return;
+        }
+
+        start_emulation(this);
 }
 
 void Frame::OnCallbackEvent(CallbackEvent &event) {


### PR DESCRIPTION
## Summary
- modify `Frame::Start` and `Frame::ShowConfigSelection` so that the configuration manager is opened before PCem performs ROM initialization

## Testing
- `cmake -S . -B build` *(fails: `FindSDL2.cmake` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd3193b8832ca916644b2b2ca346