### PR TITLE
Move model init functions

### DIFF
--- a/src/models/model.c
+++ b/src/models/model.c
@@ -59,7 +59,6 @@ void tandy1k_init();
 void tandy1ksl2_init();
 void at_init();
 void ibm_at_init();
-void at_sis496_init();
 void compaq_xt_init();
 
 extern MODEL m_amixt;
@@ -257,14 +256,6 @@ static void ps2_common_init() {
         nmi_mask = 0x80;
 }
 
-void at_sis496_init() {
-        at_init();
-        pci_init(PCI_CONFIG_TYPE_1);
-        pci_slot(0xb);
-        pci_slot(0xd);
-        pci_slot(0xf);
-        device_add(&sis496_device);
-}
 
 void model_init() {
         pclog("Initting as %s\n", model_getname());

--- a/src/models/module/amixt.c
+++ b/src/models/module/amixt.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void amixt_init() {
+        xt_init();
+}
+
 MODEL m_amixt = {"[8088] AMI XT clone",
                  ROM_AMIXT,
                  "amixt",
@@ -7,5 +12,5 @@ MODEL m_amixt = {"[8088] AMI XT clone",
                  64,
                  640,
                  64,
-                 xt_init,
+                 amixt_init,
                  NULL};

--- a/src/models/module/ataripc3.c
+++ b/src/models/module/ataripc3.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ataripc3_init() {
+        xt_init();
+}
+
 MODEL m_ataripc3 = {"[8088] Atari PC3",
                     ROM_ATARIPC3,
                     "ataripc3",
@@ -7,5 +12,5 @@ MODEL m_ataripc3 = {"[8088] Atari PC3",
                     64,
                     640,
                     64,
-                    xt_init,
+                    ataripc3_init,
                     NULL};

--- a/src/models/module/bull_micral_45.c
+++ b/src/models/module/bull_micral_45.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void bull_micral_45_init() {
+        ibm_at_init();
+}
+
 MODEL m_bull_micral_45 = {"[286] Bull Micral 45",
                           ROM_BULL_MICRAL_45,
                           "bull_micral_45",
@@ -7,5 +12,5 @@ MODEL m_bull_micral_45 = {"[286] Bull Micral 45",
                           1024,
                           6144,
                           128,
-                          ibm_at_init,
+                          bull_micral_45_init,
                           NULL};

--- a/src/models/module/cbm_pc10.c
+++ b/src/models/module/cbm_pc10.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void cbm_pc10_init() {
+        xt_init();
+}
+
 MODEL m_cbm_pc10 = {"[8088] Commodore PC-10",
                     ROM_CBM_PC10,
                     "cbm_pc10",
@@ -7,5 +12,5 @@ MODEL m_cbm_pc10 = {"[8088] Commodore PC-10",
                     640,
                     640,
                     64,
-                    xt_init,
+                    cbm_pc10_init,
                     NULL};

--- a/src/models/module/compaq_pii.c
+++ b/src/models/module/compaq_pii.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void compaq_pii_init() {
+        ibm_at_init();
+}
+
 MODEL m_compaq_pii = {"[286] Compaq Portable II",
                       ROM_COMPAQ_PII,
                       "compaq_pii",
@@ -7,5 +12,5 @@ MODEL m_compaq_pii = {"[286] Compaq Portable II",
                       256,
                       15872,
                       128,
-                      ibm_at_init,
+                      compaq_pii_init,
                       NULL};

--- a/src/models/module/compaq_pip.c
+++ b/src/models/module/compaq_pip.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void compaq_pip_init() {
+        compaq_xt_init();
+}
+
 MODEL m_compaq_pip = {"[8088] Compaq Portable Plus",
                       ROM_COMPAQ_PIP,
                       "compaq_pip",
@@ -7,5 +12,5 @@ MODEL m_compaq_pip = {"[8088] Compaq Portable Plus",
                       128,
                       640,
                       64,
-                      compaq_xt_init,
+                      compaq_pip_init,
                       NULL};

--- a/src/models/module/deskpro.c
+++ b/src/models/module/deskpro.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void deskpro_init() {
+        compaq_xt_init();
+}
+
 MODEL m_deskpro = {"[8086] Compaq Deskpro", ROM_DESKPRO, "deskpro", {{"", cpus_8086}, {"", NULL}, {"", NULL}},
                    MODEL_GFX_NONE,          128,         640,       128,
-                   compaq_xt_init,          NULL};
+                   deskpro_init,          NULL};

--- a/src/models/module/dtk.c
+++ b/src/models/module/dtk.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void dtk_init() {
+        xt_init();
+}
+
 MODEL m_dtk = {"[8088] DTK XT clone",
                ROM_DTKXT,
                "dtk",
@@ -7,5 +12,5 @@ MODEL m_dtk = {"[8088] DTK XT clone",
                64,
                640,
                64,
-               xt_init,
+               dtk_init,
                NULL};

--- a/src/models/module/epson_pcax.c
+++ b/src/models/module/epson_pcax.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void epson_pcax_init() {
+        at_init();
+}
+
 MODEL m_epson_pcax = {"[286] Epson PC AX",
                       ROM_EPSON_PCAX,
                       "epson_pcax",
@@ -7,5 +12,5 @@ MODEL m_epson_pcax = {"[286] Epson PC AX",
                       256,
                       15872,
                       128,
-                      at_init,
+                      epson_pcax_init,
                       NULL};

--- a/src/models/module/epson_pcax2e.c
+++ b/src/models/module/epson_pcax2e.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void epson_pcax2e_init() {
+        at_init();
+}
+
 MODEL m_epson_pcax2e = {"[286] Epson PC AX2e",
                         ROM_EPSON_PCAX2E,
                         "epson_pcax2e",
@@ -7,7 +12,7 @@ MODEL m_epson_pcax2e = {"[286] Epson PC AX2e",
                         256,
                         15872,
                         128,
-                        at_init,
+                        epson_pcax2e_init,
                         NULL};
 
 

--- a/src/models/module/epson_pcax3.c
+++ b/src/models/module/epson_pcax3.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void epson_pcax3_init() {
+        at_init();
+}
+
 MODEL m_epson_pcax3 = {"[386SX] Epson PC AX3",
                        ROM_EPSON_PCAX3,
                        "epson_pcax3",
@@ -7,7 +12,7 @@ MODEL m_epson_pcax3 = {"[386SX] Epson PC AX3",
                        256,
                        15872,
                        128,
-                       at_init,
+                       epson_pcax3_init,
                        NULL};
 
 

--- a/src/models/module/genxt.c
+++ b/src/models/module/genxt.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void genxt_init() {
+        xt_init();
+}
+
 MODEL m_genxt = {"[8088] Generic XT clone",
                  ROM_GENXT,
                  "genxt",
@@ -7,5 +12,5 @@ MODEL m_genxt = {"[8088] Generic XT clone",
                  32,
                  704,
                  16,
-                 xt_init,
+                 genxt_init,
                  NULL};

--- a/src/models/module/ibmat.c
+++ b/src/models/module/ibmat.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ibmat_init() {
+        ibm_at_init();
+}
+
 MODEL m_ibmat = {"[286] IBM AT",
                  ROM_IBMAT,
                  "ibmat",
@@ -7,5 +12,5 @@ MODEL m_ibmat = {"[286] IBM AT",
                  256,
                  15872,
                  128,
-                 ibm_at_init,
+                 ibmat_init,
                  NULL};

--- a/src/models/module/ibmpc.c
+++ b/src/models/module/ibmpc.c
@@ -1,3 +1,8 @@
 #include "module/common.h"
+
+void ibmpc_init() {
+        xt_init();
+}
+
 MODEL m_ibmpc = {"[8088] IBM PC", ROM_IBMPC, "ibmpc", {{"", cpus_8088}, {"", NULL}, {"", NULL}}, MODEL_GFX_NONE, 64, 640, 32,
-                 xt_init,         NULL};
+                 ibmpc_init,         NULL};

--- a/src/models/module/ibmpcjr.c
+++ b/src/models/module/ibmpcjr.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ibmpcjr_init_model() {
+        pcjr_init();
+}
+
 MODEL m_ibmpcjr = {"[8088] IBM PCjr", ROM_IBMPCJR, "ibmpcjr", {{"", cpus_pcjr}, {"", NULL}, {"", NULL}},
                    MODEL_GFX_FIXED,   128,         640,       64,
-                   pcjr_init,         &pcjr_device};
+                   ibmpcjr_init_model,         &pcjr_device};

--- a/src/models/module/ibmxt.c
+++ b/src/models/module/ibmxt.c
@@ -1,3 +1,8 @@
 #include "module/common.h"
+
+void ibmxt_init_model() {
+        xt_init();
+}
+
 MODEL m_ibmxt = {"[8088] IBM XT", ROM_IBMXT, "ibmxt", {{"", cpus_8088}, {"", NULL}, {"", NULL}}, MODEL_GFX_NONE, 64, 640, 64,
-                 xt_init,         NULL};
+                 ibmxt_init_model,         NULL};

--- a/src/models/module/ibmxt286.c
+++ b/src/models/module/ibmxt286.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ibmxt286_init() {
+        ibm_at_init();
+}
+
 MODEL m_ibmxt286 = {"[286] IBM XT Model 286",
                     ROM_IBMXT286,
                     "ibmxt286",
@@ -7,6 +12,6 @@ MODEL m_ibmxt286 = {"[286] IBM XT Model 286",
                     256,
                     15872,
                     128,
-                    ibm_at_init,
+                    ibmxt286_init,
                     NULL};
 

--- a/src/models/module/jukopc.c
+++ b/src/models/module/jukopc.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void jukopc_init() {
+        xt_init();
+}
+
 MODEL m_jukopc = {"[8088] Juko XT clone",
                   ROM_JUKOPC,
                   "jukopc",
@@ -7,5 +12,5 @@ MODEL m_jukopc = {"[8088] Juko XT clone",
                   64,
                   640,
                   64,
-                  xt_init,
+                  jukopc_init,
                   NULL};

--- a/src/models/module/ledge_modelm.c
+++ b/src/models/module/ledge_modelm.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ledge_modelm_init() {
+        xt_init();
+}
+
 MODEL m_ledge_modelm = {"[8088] Leading Edge Model M",
                         ROM_LEDGE_MODELM,
                         "ledge_modelm",
@@ -7,5 +12,5 @@ MODEL m_ledge_modelm = {"[8088] Leading Edge Model M",
                         128,
                         704,
                         64,
-                        xt_init,
+                        ledge_modelm_init,
                         NULL};

--- a/src/models/module/ncr_pc4i.c
+++ b/src/models/module/ncr_pc4i.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void ncr_pc4i_init() {
+        xt_init();
+}
+
 MODEL m_ncr_pc4i = {"[8088] NCR PC4i", ROM_NCR_PC4I, "ncr_pc4i", {{"", cpus_8088}, {"", NULL}, {"", NULL}},
                     MODEL_GFX_NONE,    256,          640,        64,
-                    xt_init,           NULL};
+                    ncr_pc4i_init,           NULL};

--- a/src/models/module/pxxt.c
+++ b/src/models/module/pxxt.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void pxxt_init() {
+        xt_init();
+}
+
 MODEL m_pxxt = {"[8088] Phoenix XT clone",
                 ROM_PXXT,
                 "pxxt",
@@ -7,5 +12,5 @@ MODEL m_pxxt = {"[8088] Phoenix XT clone",
                 64,
                 640,
                 64,
-                xt_init,
+                pxxt_init,
                 NULL};

--- a/src/models/module/sis496.c
+++ b/src/models/module/sis496.c
@@ -1,4 +1,14 @@
 #include "module/common.h"
+
+void at_sis496_init() {
+        at_init();
+        pci_init(PCI_CONFIG_TYPE_1);
+        pci_slot(0xb);
+        pci_slot(0xd);
+        pci_slot(0xf);
+        device_add(&sis496_device);
+}
+
 MODEL m_sis496 = {"[486] Award SiS 496/497",
                   ROM_SIS496,
                   "sis496",

--- a/src/models/module/super16t.c
+++ b/src/models/module/super16t.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void super16t_init() {
+        xt_init();
+}
+
 MODEL m_super16t = {"[8088] Hyundai Super16T",
                      ROM_HYUNDAI_SUPER16T,
                      "super16t",
@@ -7,5 +12,5 @@ MODEL m_super16t = {"[8088] Hyundai Super16T",
                      640,
                      640,
                      64,
-                     xt_init,
+                     super16t_init,
                      NULL};

--- a/src/models/module/super16te.c
+++ b/src/models/module/super16te.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void super16te_init() {
+        xt_init();
+}
+
 MODEL m_super16te = {"[8088] Hyundai Super16TE",
                       ROM_HYUNDAI_SUPER16TE,
                       "super16te",
@@ -7,5 +12,5 @@ MODEL m_super16te = {"[8088] Hyundai Super16TE",
                       640,
                       640,
                       64,
-                      xt_init,
+                      super16te_init,
                       NULL};

--- a/src/models/module/tandy.c
+++ b/src/models/module/tandy.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void tandy_init_model() {
+        tandy1k_init();
+}
+
 MODEL m_tandy = {
         "[8088] Tandy 1000", ROM_TANDY,        "tandy", {{"", cpus_8088}, {"", NULL}, {"", NULL}}, MODEL_GFX_FIXED, 128, 640, 128,
-        tandy1k_init,        &tandy1000_device};
+        tandy_init_model,        &tandy1000_device};

--- a/src/models/module/tandy1000hx.c
+++ b/src/models/module/tandy1000hx.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void tandy1000hx_init() {
+        tandy1k_init();
+}
+
 MODEL m_tandy1000hx = {"[8088] Tandy 1000 HX",
                        ROM_TANDY1000HX,
                        "tandy1000hx",
@@ -7,5 +12,5 @@ MODEL m_tandy1000hx = {"[8088] Tandy 1000 HX",
                        256,
                        640,
                        128,
-                       tandy1k_init,
+                       tandy1000hx_init,
                        &tandy1000hx_device};

--- a/src/models/module/tandy1000sl2.c
+++ b/src/models/module/tandy1000sl2.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void tandy1000sl2_init_model() {
+        tandy1ksl2_init();
+}
+
 MODEL m_tandy1000sl2 = {"[8086] Tandy 1000 SL/2",
                         ROM_TANDY1000SL2,
                         "tandy1000sl2",
@@ -7,7 +12,7 @@ MODEL m_tandy1000sl2 = {"[8086] Tandy 1000 SL/2",
                         512,
                         768,
                         128,
-                        tandy1ksl2_init,
+                        tandy1000sl2_init_model,
                         NULL};
 /* 286 PC's */
 

--- a/src/models/module/to16_pc.c
+++ b/src/models/module/to16_pc.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void to16_pc_init() {
+        xt_init();
+}
+
 MODEL m_to16_pc = {"[8088] Thomson TO16 PC",
                    ROM_TO16_PC,
                    "to16_pc",
@@ -7,6 +12,6 @@ MODEL m_to16_pc = {"[8088] Thomson TO16 PC",
                    512,
                    640,
                    128,
-                   xt_init,
+                   to16_pc_init,
                    NULL};
 

--- a/src/models/module/tulip_tc7.c
+++ b/src/models/module/tulip_tc7.c
@@ -1,4 +1,9 @@
 #include "module/common.h"
+
+void tulip_tc7_init() {
+        ibm_at_init();
+}
+
 MODEL m_tulip_tc7 = {"[286] Tulip AT Compact",
                      ROM_TULIP_TC7,
                      "tulip_tc7",
@@ -7,7 +12,7 @@ MODEL m_tulip_tc7 = {"[286] Tulip AT Compact",
                      640,
                      15872,
                      128,
-                     ibm_at_init,
+                     tulip_tc7_init,
                      NULL};
 
 


### PR DESCRIPTION
## Summary
- add individual init functions in each module file
- remove at_sis496_init implementation from model.c
- build project to ensure no compile errors

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`


------
https://chatgpt.com/codex/tasks/task_e_687c263a0e6c832cbf6ebc92d0c3a3f8