### PR TITLE
Add function call tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ if(${PCEM_CPU_TYPE} STREQUAL "x86_64")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64-v2")
 endif()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -finstrument-functions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -finstrument-functions")
+
 set(PCEM_VERSION_STRING "vNext" CACHE STRING "PCem Version String")
 set(PCEM_DISPLAY_ENGINE "wxWidgets" CACHE STRING "PCem Display Engine")
 set(PCEM_DEFINES ${PCEM_DEFINES} PCEM_VERSION_STRING="${PCEM_VERSION_STRING}")
@@ -204,6 +207,7 @@ if(USE_NETWORKING AND USE_PCAP_NETWORKING)
 endif()
 
 find_package(OpenGL REQUIRED)
+set(PCEM_ADDITIONAL_LIBS ${PCEM_ADDITIONAL_LIBS} dl)
 
 add_subdirectory(src)
 

--- a/includes/private/func_trace.h
+++ b/includes/private/func_trace.h
@@ -1,0 +1,15 @@
+#ifndef FUNC_TRACE_H
+#define FUNC_TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void instrumentation_init(void);
+void instrumentation_close(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FUNC_TRACE_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ set(PCEM_SRC ${PCEM_SRC}
         rtc.c
         rtc_tc8521.c
         timer.c
+        instrumentation.c
         )
 
 set(PCEM_LIBRARIES ${DISPLAY_ENGINE_LIBRARIES} ${SDL2_LIBRARIES} ${OPENAL_LIBRARY} ${OPENGL_LIBRARIES} ${PCEM_ADDITIONAL_LIBS})

--- a/src/instrumentation.c
+++ b/src/instrumentation.c
@@ -1,0 +1,74 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include "plugin-api/paths.h"
+#include "func_trace.h"
+
+static FILE *trace_file = NULL;
+
+__attribute__((no_instrument_function))
+static void open_trace(void) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%sfunction.log", logs_path);
+    trace_file = fopen(path, "w");
+}
+
+__attribute__((no_instrument_function))
+void instrumentation_init(void) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%sfunction.log", logs_path);
+    unlink(path);
+    if (trace_file) {
+        fclose(trace_file);
+    }
+    trace_file = fopen(path, "w");
+}
+
+__attribute__((no_instrument_function))
+void instrumentation_close(void) {
+    if (trace_file) {
+        fclose(trace_file);
+        trace_file = NULL;
+    }
+}
+
+__attribute__((no_instrument_function))
+static const char *symname(void *func) {
+    Dl_info info;
+    if (dladdr(func, &info) && info.dli_sname)
+        return info.dli_sname;
+    return NULL;
+}
+
+__attribute__((no_instrument_function))
+void __cyg_profile_func_enter(void *func, void *caller) {
+    (void)caller;
+    if (!trace_file)
+        open_trace();
+    const char *name = symname(func);
+    if (name)
+        fprintf(trace_file, "ENTER %s\n", name);
+    else
+        fprintf(trace_file, "ENTER %p\n", func);
+}
+
+__attribute__((no_instrument_function))
+void __cyg_profile_func_exit(void *func, void *caller) {
+    (void)caller;
+    if (!trace_file)
+        open_trace();
+    const char *name = symname(func);
+    if (name)
+        fprintf(trace_file, "EXIT %s\n", name);
+    else
+        fprintf(trace_file, "EXIT %p\n", func);
+}
+
+__attribute__((no_instrument_function))
+static void instrumentation_destructor(void) __attribute__((destructor));
+__attribute__((no_instrument_function))
+static void instrumentation_destructor(void) {
+    instrumentation_close();
+}

--- a/src/wx-ui/wx-sdl2.c
+++ b/src/wx-ui/wx-sdl2.c
@@ -435,6 +435,7 @@ void sdl_onconfigloaded() {
 
 extern void wx_loadconfig();
 extern void wx_saveconfig();
+#include "func_trace.h"
 
 int pc_main(int argc, char **argv) {
         // Expose some functions to libpcem-plugin-api without moving them over to
@@ -445,6 +446,7 @@ int pc_main(int argc, char **argv) {
         _sound_speed_changed = sound_speed_changed;
 
         paths_init();
+        instrumentation_init();
 
         init_plugin_engine();
         model_init_builtin();


### PR DESCRIPTION
## Summary
- enable Clang `-finstrument-functions` to trace all function calls
- link against `dl` for symbol lookup
- implement `instrumentation.c` to log entry/exit of functions
- add tracing header and compile it
- call `instrumentation_init` at emulator startup

## Testing
- `cmake .. -G Ninja` *(fails: Could NOT find PCAP)*
- `ninja` *(fails: linker command failed)*

------
https://chatgpt.com/codex/tasks/task_e_687cb71d37fc832c9fb7a59a1d85872c