### PR TITLE
Add option for no keyboard

### DIFF
--- a/includes/private/keyboard/keyboard.h
+++ b/includes/private/keyboard/keyboard.h
@@ -9,6 +9,13 @@ extern uint8_t pcem_key[272];
 
 enum { SCANCODE_SET_1, SCANCODE_SET_2, SCANCODE_SET_3 };
 
+enum { KEYBOARD_TYPE_NONE, KEYBOARD_TYPE_AT, KEYBOARD_TYPE_XT, KEYBOARD_TYPE_PCJR, KEYBOARD_TYPE_OLIM24, KEYBOARD_TYPE_MAX };
+
+extern int keyboard_type;
+
+const char *keyboard_get_name(int type);
+void keyboard_set_type(int type);
+
 void keyboard_set_scancode_set(int set);
 void keyboard_send_scancode(int code, int is_break);
 

--- a/includes/private/keyboard/keyboard_none.h
+++ b/includes/private/keyboard/keyboard_none.h
@@ -1,0 +1,5 @@
+#ifndef _KEYBOARD_NONE_H_
+#define _KEYBOARD_NONE_H_
+void keyboard_none_init();
+void keyboard_none_poll();
+#endif /* _KEYBOARD_NONE_H_ */

--- a/includes/private/keyboard/keyboard_olim24.h
+++ b/includes/private/keyboard/keyboard_olim24.h
@@ -4,6 +4,7 @@ void keyboard_olim24_init();
 void keyboard_olim24_reset();
 void keyboard_olim24_poll();
 
+#include "mouse.h"
 extern mouse_t mouse_olim24;
 
 #endif /* _KEYBOARD_OLIM24_H_ */

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -1,6 +1,11 @@
 #include "ibm.h"
 #include "plat-keyboard.h"
 #include "keyboard.h"
+#include "keyboard_xt.h"
+#include "keyboard_at.h"
+#include "keyboard_pcjr.h"
+#include "keyboard_olim24.h"
+#include "keyboard_none.h"
 
 int keybsendcallback = 0;
 
@@ -1482,5 +1487,47 @@ void keyboard_send_scancode(int code, int is_break) {
         } else {
                 while (scancodes[code].scancodes_break[d] != 0)
                         keyboard_send(scancodes[code].scancodes_break[d++]);
+        }
+}
+
+int keyboard_type = KEYBOARD_TYPE_AT;
+
+const char *keyboard_get_name(int type) {
+        switch (type) {
+        case KEYBOARD_TYPE_NONE:
+                return "None";
+        case KEYBOARD_TYPE_AT:
+                return "AT";
+        case KEYBOARD_TYPE_XT:
+                return "XT";
+        case KEYBOARD_TYPE_PCJR:
+                return "PCjr";
+        case KEYBOARD_TYPE_OLIM24:
+                return "Olivetti M24";
+        default:
+                return NULL;
+        }
+}
+
+void keyboard_set_type(int type) {
+        keyboard_type = type;
+
+        switch (type) {
+        case KEYBOARD_TYPE_NONE:
+                keyboard_none_init();
+                break;
+        case KEYBOARD_TYPE_XT:
+                keyboard_xt_init();
+                break;
+        case KEYBOARD_TYPE_PCJR:
+                keyboard_pcjr_init();
+                break;
+        case KEYBOARD_TYPE_OLIM24:
+                keyboard_olim24_init();
+                break;
+        case KEYBOARD_TYPE_AT:
+        default:
+                keyboard_at_init();
+                break;
         }
 }

--- a/src/keyboard/keyboard.cmake
+++ b/src/keyboard/keyboard.cmake
@@ -1,6 +1,7 @@
 set(PCEM_PRIVATE_API ${PCEM_PRIVATE_API}
         ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard_at.h
         ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard.h
+        ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard_none.h
         ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard_olim24.h
         ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard_pcjr.h
         ${CMAKE_SOURCE_DIR}/includes/private/keyboard/keyboard_xt.h
@@ -9,6 +10,7 @@ set(PCEM_PRIVATE_API ${PCEM_PRIVATE_API}
 set(PCEM_SRC ${PCEM_SRC}
         keyboard/keyboard.c
         keyboard/keyboard_at.c
+        keyboard/keyboard_none.c
         keyboard/keyboard_olim24.c
         keyboard/keyboard_pcjr.c
         keyboard/keyboard_xt.c

--- a/src/keyboard/keyboard_none.c
+++ b/src/keyboard/keyboard_none.c
@@ -1,0 +1,26 @@
+#include "ibm.h"
+#include "io.h"
+#include "keyboard.h"
+
+static uint8_t keyboard_none_read(uint16_t port, void *priv) {
+        /* Return 0xff to indicate no device */
+        return 0xff;
+}
+
+static void keyboard_none_write(uint16_t port, uint8_t val, void *priv) {
+        /* Ignore writes */
+        (void)port;
+        (void)val;
+        (void)priv;
+}
+
+void keyboard_none_poll() { /* Nothing to do */ }
+
+void keyboard_none_init() {
+        /* Install dummy handlers on typical keyboard ports */
+        io_sethandler(0x0060, 0x0005, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
+        io_sethandler(0x00a0, 0x0008, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
+        keyboard_send = keyboard_none_write;
+        keyboard_poll = keyboard_none_poll;
+        keyboard_scan = 0;
+}

--- a/src/keyboard/keyboard_none.c
+++ b/src/keyboard/keyboard_none.c
@@ -14,13 +14,17 @@ static void keyboard_none_write(uint16_t port, uint8_t val, void *priv) {
         (void)priv;
 }
 
+static void keyboard_none_send(uint8_t val) {
+        (void)val;
+}
+
 void keyboard_none_poll() { /* Nothing to do */ }
 
 void keyboard_none_init() {
         /* Install dummy handlers on typical keyboard ports */
         io_sethandler(0x0060, 0x0005, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
         io_sethandler(0x00a0, 0x0008, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
-        keyboard_send = keyboard_none_write;
+        keyboard_send = keyboard_none_send;
         keyboard_poll = keyboard_none_poll;
         keyboard_scan = 0;
 }

--- a/src/keyboard/keyboard_none.c
+++ b/src/keyboard/keyboard_none.c
@@ -21,9 +21,11 @@ static void keyboard_none_send(uint8_t val) {
 void keyboard_none_poll() { /* Nothing to do */ }
 
 void keyboard_none_init() {
-        /* Install dummy handlers on typical keyboard ports */
-        io_sethandler(0x0060, 0x0005, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
-        io_sethandler(0x00a0, 0x0008, keyboard_none_read, NULL, NULL, keyboard_none_write, NULL, NULL, NULL);
+        /* Remove any existing handlers for keyboard ports so the device appears absent */
+        io_removehandler(0x0060, 0x0005, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        io_removehandler(0x00a0, 0x0008, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+        /* Use stub callbacks so keyboard events are ignored */
         keyboard_send = keyboard_none_send;
         keyboard_poll = keyboard_none_poll;
         keyboard_scan = 0;

--- a/src/pc.c
+++ b/src/pc.c
@@ -363,6 +363,7 @@ void resetpchard() {
         if (!AT && models[model]->max_ram > 640 && models[model]->max_ram <= 768 && !video_is_ega_vga())
                 mem_set_704kb();
         model_init();
+        keyboard_set_type(keyboard_type);
         mouse_emu_init();
         video_init();
         speaker_init();
@@ -765,6 +766,7 @@ void loadconfig(char *fn) {
 
         joystick_type = config_get_int(CFG_MACHINE, NULL, "joystick_type", 0);
         mouse_type = config_get_int(CFG_MACHINE, NULL, "mouse_type", 0);
+        keyboard_type = config_get_int(CFG_MACHINE, NULL, "keyboard_type", KEYBOARD_TYPE_AT);
 
         for (c = 0; c < joystick_get_max_joysticks(joystick_type); c++) {
                 sprintf(s, "joystick_%i_nr", c);
@@ -912,6 +914,7 @@ void saveconfig(char *fn) {
 
         config_set_int(CFG_MACHINE, NULL, "joystick_type", joystick_type);
         config_set_int(CFG_MACHINE, NULL, "mouse_type", mouse_type);
+        config_set_int(CFG_MACHINE, NULL, "keyboard_type", keyboard_type);
 
         for (c = 0; c < joystick_get_max_joysticks(joystick_type); c++) {
                 char s[80];

--- a/src/wx-ui/pc.xrc
+++ b/src/wx-ui/pc.xrc
@@ -1367,30 +1367,59 @@
 										<size>80,-1</size>
 										<label>Mouse:</label>
 										<wrap>-1</wrap>
-									</object>
-								</object>
-								<object class="sizeritem">
-									<option>1</option>
-									<flag>wxEXPAND</flag>
-									<border>5</border>
-									<object class="wxBoxSizer">
-										<orient>wxHORIZONTAL</orient>
-										<object class="sizeritem">
-											<option>0</option>
-											<flag>wxALL</flag>
-											<border>5</border>
-											<object class="wxComboBox" name="IDC_COMBOMOUSE">
-												<style>wxCB_DROPDOWN|wxCB_READONLY</style>
-												<size>350,-1</size>
-												<value></value>
-												<content />
-											</object>
-										</object>
-									</object>
-								</object>
-							</object>
-						</object>
-					</object>
+                                                                        </object>
+                                                                </object>
+                                                                <object class="sizeritem">
+                                                                        <option>1</option>
+                                                                        <flag>wxEXPAND</flag>
+                                                                        <border>5</border>
+                                                                        <object class="wxBoxSizer">
+                                                                                <orient>wxHORIZONTAL</orient>
+                                                                                <object class="sizeritem">
+                                                                                        <option>0</option>
+                                                                                        <flag>wxALL</flag>
+                                                                                        <border>5</border>
+                                                                                        <object class="wxComboBox" name="IDC_COMBOMOUSE">
+                                                                                                <style>wxCB_DROPDOWN|wxCB_READONLY</style>
+                                                                                                <size>350,-1</size>
+                                                                                                <value></value>
+                                                                                                <content />
+                                                                                        </object>
+                                                                                </object>
+                                                                        </object>
+                                                                </object>
+                                                                <object class="sizeritem">
+                                                                        <option>0</option>
+                                                                        <flag>wxALL | wxALIGN_CENTER_VERTICAL</flag>
+                                                                        <border>5</border>
+                                                                        <object class="wxStaticText">
+                                                                                <size>80,-1</size>
+                                                                                <label>Keyboard:</label>
+                                                                                <wrap>-1</wrap>
+                                                                        </object>
+                                                                </object>
+                                                                <object class="sizeritem">
+                                                                        <option>1</option>
+                                                                        <flag>wxEXPAND</flag>
+                                                                        <border>5</border>
+                                                                        <object class="wxBoxSizer">
+                                                                                <orient>wxHORIZONTAL</orient>
+                                                                                <object class="sizeritem">
+                                                                                        <option>0</option>
+                                                                                        <flag>wxALL</flag>
+                                                                                        <border>5</border>
+                                                                                        <object class="wxComboBox" name="IDC_COMBOKEYBOARD">
+                                                                                                <style>wxCB_DROPDOWN|wxCB_READONLY</style>
+                                                                                                <size>350,-1</size>
+                                                                                                <value></value>
+                                                                                                <content />
+                                                                                        </object>
+                                                                                </object>
+                                                                        </object>
+                                                                </object>
+                                                        </object>
+                                                </object>
+                                        </object>
 					<object class="simplebookpage">
 						<selected>0</selected>
 						<object class="wxPanel">

--- a/src/wx-ui/wx-config.c
+++ b/src/wx-ui/wx-config.c
@@ -653,6 +653,7 @@ int config_dlgproc(void *hdlg, int message, INT_PARAM wParam, LONG_PARAM lParam)
         int cpu_type;
         int temp_cd_model, temp_cd_speed;
         int temp_mouse_type;
+        int temp_keyboard_type;
         int temp_lpt1_current;
 #ifdef USE_NETWORKING
         int temp_network_card;

--- a/src/wx-ui/wx-config.c
+++ b/src/wx-ui/wx-config.c
@@ -12,6 +12,7 @@
 #include "lpt.h"
 #include "model.h"
 #include "mouse.h"
+#include "keyboard.h"
 #include "mem.h"
 #include "nethandler.h"
 #include "nvr.h"
@@ -30,6 +31,7 @@ extern int is486;
 static int romstolist[ROM_MAX], listtomodel[ROM_MAX], romstomodel[ROM_MAX], modeltolist[ROM_MAX];
 static int settings_sound_to_list[20], settings_list_to_sound[20];
 static int settings_mouse_to_list[20], settings_list_to_mouse[20];
+static int settings_keyboard_to_list[20], settings_list_to_keyboard[20];
 #ifdef USE_NETWORKING
 static int settings_network_to_list[20], settings_list_to_network[20];
 #endif
@@ -451,6 +453,7 @@ int config_dlgsave(void *hdlg) {
         int temp_dynarec;
         int temp_fda_type, temp_fdb_type;
         int temp_mouse_type;
+        int temp_keyboard_type;
         int temp_lpt1_device;
         int temp_joystick_type;
 #ifdef USE_NETWORKING
@@ -519,6 +522,9 @@ int config_dlgsave(void *hdlg) {
         h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOMOUSE"));
         temp_mouse_type = settings_list_to_mouse[wx_sendmessage(h, WX_CB_GETCURSEL, 0, 0)];
 
+        h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOKEYBOARD"));
+        temp_keyboard_type = wx_sendmessage(h, WX_CB_GETCURSEL, 0, 0);
+
         h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOHDD"));
         c = wx_sendmessage(h, WX_CB_GETCURSEL, 0, 0);
         if (hdd_names[c])
@@ -535,7 +541,7 @@ int config_dlgsave(void *hdlg) {
         if (temp_model != model || gfx != gfxcard || mem != mem_size || temp_fpu != fpu_type || temp_GAMEBLASTER != GAMEBLASTER ||
             temp_GUS != GUS || temp_SSI2001 != SSI2001 || temp_sound_card_current != sound_card_current ||
             temp_voodoo != voodoo_enabled || temp_dynarec != cpu_use_dynarec || temp_fda_type != fdd_get_type(0) ||
-            temp_fdb_type != fdd_get_type(1) || temp_mouse_type != mouse_type || hdd_changed || hd_changed ||
+            temp_fdb_type != fdd_get_type(1) || temp_mouse_type != mouse_type || temp_keyboard_type != keyboard_type || hdd_changed || hd_changed ||
             cdrom_channel != new_cdrom_channel || zip_channel != new_zip_channel || lpt1_current != temp_lpt1_device
 #ifdef USE_NETWORKING
             || temp_network_card != network_card_current
@@ -558,6 +564,7 @@ int config_dlgsave(void *hdlg) {
                         voodoo_enabled = temp_voodoo;
                         cpu_use_dynarec = temp_dynarec;
                         mouse_type = temp_mouse_type;
+                        keyboard_type = temp_keyboard_type;
                         strcpy(lpt1_device_name, lpt_device_get_internal_name(temp_lpt1_device));
 #ifdef USE_NETWORKING
                         network_card_current = temp_network_card;
@@ -854,6 +861,17 @@ int config_dlgproc(void *hdlg, int message, INT_PARAM wParam, LONG_PARAM lParam)
                 }
                 wx_sendmessage(h, WX_CB_SETCURSEL, settings_mouse_to_list[mouse_type], 0);
 
+                h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOKEYBOARD"));
+                c = 0;
+                while (1) {
+                        const char *s = keyboard_get_name(c);
+                        if (!s)
+                                break;
+                        wx_sendmessage(h, WX_CB_ADDSTRING, 0, (LONG_PARAM)s);
+                        c++;
+                }
+                wx_sendmessage(h, WX_CB_SETCURSEL, keyboard_type, 0);
+
                 h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOLPT1"));
                 c = d = 0;
                 while (1) {
@@ -1023,17 +1041,30 @@ int config_dlgproc(void *hdlg, int message, INT_PARAM wParam, LONG_PARAM lParam)
                                 if (mouse_valid(type, temp_model)) {
                                         wx_sendmessage(h, WX_CB_ADDSTRING, 0, (LONG_PARAM)s);
 
-                                        settings_list_to_mouse[d] = c;
-                                        d++;
-                                }
+                                settings_list_to_mouse[d] = c;
+                                d++;
+                        }
 
-                                c++;
+                        c++;
                         }
 
                         if (mouse_valid(mouse_get_type(temp_mouse_type), temp_model))
                                 wx_sendmessage(h, WX_CB_SETCURSEL, settings_mouse_to_list[temp_mouse_type], 0);
                         else
                                 wx_sendmessage(h, WX_CB_SETCURSEL, 0, 0);
+
+                        h = wx_getdlgitem(hdlg, WX_ID("IDC_COMBOKEYBOARD"));
+                        temp_keyboard_type = wx_sendmessage(h, WX_CB_GETCURSEL, 0, 0);
+                        wx_sendmessage(h, WX_CB_RESETCONTENT, 0, 0);
+                        c = 0;
+                        while (1) {
+                                const char *s = keyboard_get_name(c);
+                                if (!s)
+                                        break;
+                                wx_sendmessage(h, WX_CB_ADDSTRING, 0, (LONG_PARAM)s);
+                                c++;
+                        }
+                        wx_sendmessage(h, WX_CB_SETCURSEL, temp_keyboard_type, 0);
 
                         recalc_vid_list(hdlg, temp_model, force_builtin_video);
 


### PR DESCRIPTION
## Summary
- add KEYBOARD_TYPE_NONE and handling
- implement keyboard_none driver for missing keyboards
- include keyboard_none in build

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_687ea38e3164832c8ae8873dbd0d1f52