### PR TITLE
Add BIOS port search helper

### DIFF
--- a/tools/bios_port_search.py
+++ b/tools/bios_port_search.py
@@ -1,0 +1,57 @@
+import argparse
+import subprocess
+import re
+from pathlib import Path
+
+
+def disassemble(bios_path: Path) -> list[str]:
+    """Disassemble binary BIOS file using objdump."""
+    cmd = [
+        "objdump",
+        "-D",
+        "-b",
+        "binary",
+        "-m",
+        "i8086",
+        str(bios_path),
+    ]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+    return result.stdout.splitlines()
+
+
+def search_ports(asm_lines: list[str], ports: list[int]) -> list[str]:
+    """Search assembly lines for in/out instructions to given ports."""
+    hits = []
+    pattern = re.compile(r"\b(in|out)\b[^$]*\$0x([0-9a-fA-F]+)")
+    for line in asm_lines:
+        match = pattern.search(line)
+        if match:
+            port = int(match.group(2), 16)
+            if port in ports:
+                hits.append(line)
+    return hits
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search BIOS for IN/OUT port instructions")
+    parser.add_argument("bios", type=Path, help="Path to BIOS binary")
+    parser.add_argument("-p", "--ports", nargs="+", default=["A0", "3D8"],
+                        help="Ports to search for in hex, e.g. A0 3D8")
+    args = parser.parse_args()
+
+    ports = [int(p, 16) for p in args.ports]
+    asm_lines = disassemble(args.bios)
+    hits = search_ports(asm_lines, ports)
+
+    if hits:
+        print("Found instructions:")
+        for line in hits:
+            print(line)
+    else:
+        print("No matching instructions found")
+
+    print(f"Total matches: {len(hits)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `bios_port_search.py` script to help locate port I/O operations in BIOS binaries

## Testing
- `python3 tools/bios_port_search.py --help`
- `python3 tools/bios_port_search.py sample.bin` (dummy file)

------
https://chatgpt.com/codex/tasks/task_e_68851b6be7d0832cb24428301bd35e00