### PR TITLE
Add timestamps to port log entries

### DIFF
--- a/src/plugin-api/portlog.c
+++ b/src/plugin-api/portlog.c
@@ -4,10 +4,11 @@
 #include <errno.h>
 #include "config.h"
 #include "paths.h"
-#include "ibm.h"
+#include <SDL.h>
 
 static FILE *portlogf = NULL;
 static uint64_t portlog_start_time = 0;
+static uint64_t portlog_freq = 0;
 
 static int portlog_start() {
 #ifndef RELEASE_BUILD
@@ -21,7 +22,8 @@ static int portlog_start() {
             fprintf(stderr, "Could not open port log file for writing: %s", strerror(errno));
             return 0;
         }
-        portlog_start_time = timer_read();
+        portlog_freq = SDL_GetPerformanceFrequency();
+        portlog_start_time = SDL_GetPerformanceCounter();
     }
     return 1;
 #else
@@ -51,11 +53,13 @@ void portlog(const char *format, ...) {
     char buf[1024];
     if (!portlog_start())
         return;
+    if (!portlog_freq)
+        portlog_freq = SDL_GetPerformanceFrequency();
     if (!portlog_start_time)
-        portlog_start_time = timer_read();
-    uint64_t now = timer_read();
+        portlog_start_time = SDL_GetPerformanceCounter();
+    uint64_t now = SDL_GetPerformanceCounter();
     double ms = ((double)(now - portlog_start_time) * 1000.0) /
-                (double)timer_freq;
+                (double)portlog_freq;
     va_list ap;
     va_start(ap, format);
     vsprintf(buf, format, ap);

--- a/src/plugin-api/portlog.c
+++ b/src/plugin-api/portlog.c
@@ -4,8 +4,10 @@
 #include <errno.h>
 #include "config.h"
 #include "paths.h"
+#include "ibm.h"
 
 static FILE *portlogf = NULL;
+static uint64_t portlog_start_time = 0;
 
 static int portlog_start() {
 #ifndef RELEASE_BUILD
@@ -19,6 +21,7 @@ static int portlog_start() {
             fprintf(stderr, "Could not open port log file for writing: %s", strerror(errno));
             return 0;
         }
+        portlog_start_time = timer_read();
     }
     return 1;
 #else
@@ -48,10 +51,16 @@ void portlog(const char *format, ...) {
     char buf[1024];
     if (!portlog_start())
         return;
+    if (!portlog_start_time)
+        portlog_start_time = timer_read();
+    uint64_t now = timer_read();
+    double ms = ((double)(now - portlog_start_time) * 1000.0) /
+                (double)timer_freq;
     va_list ap;
     va_start(ap, format);
     vsprintf(buf, format, ap);
     va_end(ap);
-    fputs(buf, portlogf);
+    fprintf(portlogf, "[%10.3f ms] %s", ms, buf);
+    fflush(portlogf);
 #endif
 }


### PR DESCRIPTION
## Summary
- log port I/O time using timer_read and timer_freq
- flush after each port log entry
- report timestamp in milliseconds for better clarity when events happen quickly

## Testing
- `bash tools/build_tests.sh` (no output indicates successful compilation)
- `tests/test_init`
- `tests/test_device_init`


------
https://chatgpt.com/codex/tasks/task_e_688a1efa9ec4832c8f17a44627a01dba