### PR TITLE
Modify portlog format

### DIFF
--- a/src/plugin-api/portlog.c
+++ b/src/plugin-api/portlog.c
@@ -68,8 +68,7 @@ void portlog(const char *format, ...) {
     size_t len = strlen(buf);
     if (len && buf[len - 1] == '\n')
         buf[len - 1] = '\0';
-    fprintf(portlogf, "%s [%10.3f ms] index: %llu\n", buf, ms,
-            (unsigned long long)portlog_index++);
+    fprintf(portlogf, "index: %llu %s [%10.3f ms]\n", (unsigned long long)portlog_index++, buf, ms);
     fflush(portlogf);
 #endif
 }

--- a/src/plugin-api/portlog.c
+++ b/src/plugin-api/portlog.c
@@ -9,6 +9,7 @@
 static FILE *portlogf = NULL;
 static uint64_t portlog_start_time = 0;
 static uint64_t portlog_freq = 0;
+static uint64_t portlog_index = 0;
 
 static int portlog_start() {
 #ifndef RELEASE_BUILD
@@ -62,9 +63,13 @@ void portlog(const char *format, ...) {
                 (double)portlog_freq;
     va_list ap;
     va_start(ap, format);
-    vsprintf(buf, format, ap);
+    vsnprintf(buf, sizeof(buf), format, ap);
     va_end(ap);
-    fprintf(portlogf, "[%10.3f ms] %s", ms, buf);
+    size_t len = strlen(buf);
+    if (len && buf[len - 1] == '\n')
+        buf[len - 1] = '\0';
+    fprintf(portlogf, "%s [%10.3f ms] index: %llu\n", buf, ms,
+            (unsigned long long)portlog_index++);
     fflush(portlogf);
 #endif
 }


### PR DESCRIPTION
## Summary
- add index counter to `portlog`
- print log time and index after the log message

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON .`
- `ninja`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688afeca0b00832c8a0680cbe6d83a2f